### PR TITLE
Updated permissions for commmands

### DIFF
--- a/src/commands/config/EditPrefix.ts
+++ b/src/commands/config/EditPrefix.ts
@@ -16,7 +16,7 @@ export default class EditPrefix extends ConfigCommand {
             1,
             '[prefix]',
             undefined,
-            ["ADMINISTRATOR"],
+            [],
             UserLevel.admin,
             ["prefix"]
         );
@@ -25,7 +25,6 @@ export default class EditPrefix extends ConfigCommand {
     async execute(message: Message, botSystem: BotSystem, args: any, autoDelete: boolean, autoDeleteTime: number): Promise<void> {
         if (
             !message.member
-            || !message.member.permissions.has("ADMINISTRATOR")
         ) {
             message.channel.send(botSystem.translator.translateUppercase("you need to be an administrator to do that"));
             return;

--- a/src/commands/config/Reset.ts
+++ b/src/commands/config/Reset.ts
@@ -16,7 +16,7 @@ export default class Reset extends ConfigCommand {
             undefined,
             undefined,
             undefined,
-            ["ADMINISTRATOR"],
+            [],
             UserLevel.admin
         )
     }
@@ -24,7 +24,6 @@ export default class Reset extends ConfigCommand {
 	async execute(message: Message, botSystem: BotSystem, args: any) {
         if(
             !message.member
-            || !message.member.permissions.has("ADMINISTRATOR")
         ) {
             message.channel.send(botSystem.translator.translateUppercase("you need to be an administrator to do that"));
             return;

--- a/src/commands/group/Group.ts
+++ b/src/commands/group/Group.ts
@@ -17,7 +17,7 @@ export default class Group extends GroupCommand {
             2,
             '[group name] [group members]',
             undefined,
-            ["ADMINISTRATOR"],
+            [],
             UserLevel.admin
         )
     }
@@ -26,7 +26,6 @@ export default class Group extends GroupCommand {
         // Check permissions
         if (
             !message.member
-            || !message.member.permissions.has("ADMINISTRATOR")
         ) {
             message.channel.send(botSystem.translator.translateUppercase("you do not have the right permissions to use this command"));
             return;

--- a/src/commands/group/GroupsCreated.ts
+++ b/src/commands/group/GroupsCreated.ts
@@ -16,7 +16,7 @@ export default class GroupsCreated extends GroupCommand {
             undefined,
             undefined,
             undefined,
-            ["ADMINISTRATOR"],
+            [],
             UserLevel.admin
         );
     }
@@ -25,7 +25,6 @@ export default class GroupsCreated extends GroupCommand {
         // Check permissions
         if (
             !message.member
-            || !message.member.permissions.has("ADMINISTRATOR")
         ) {
             message.channel.send(botSystem.translator.translateUppercase("you do not have the right permissions to use this command"));
             return;

--- a/src/commands/group/SimpleGroup.ts
+++ b/src/commands/group/SimpleGroup.ts
@@ -16,7 +16,7 @@ export default class SimpleGroup extends GroupCommand {
             2,
             '[group name] [group members / roles]',
             undefined,
-            ["ADMINISTRATOR", "MANAGE_CHANNELS"],
+            [],
             UserLevel.admin
         )
     }
@@ -25,8 +25,6 @@ export default class SimpleGroup extends GroupCommand {
         // Check permissions
         if (
             !message.member
-            || !message.member.permissions.has("MANAGE_CHANNELS")
-            || !message.member.permissions.has("ADMINISTRATOR")
         ) {
             message.channel.send(botSystem.translator.translateUppercase("you do not have the right permissions to use this command"));
             return;

--- a/src/commands/team/TeamConfig.ts
+++ b/src/commands/team/TeamConfig.ts
@@ -21,7 +21,7 @@ export default class TeamConfig extends TeamCommand {
             0,
             '[command]',
             0,
-            [`ADMINISTRATOR`],
+            [],
             UserLevel.admin,
         );
     }
@@ -31,7 +31,6 @@ export default class TeamConfig extends TeamCommand {
 
         if (
             !message.member
-            || !message.member.permissions.has(`ADMINISTRATOR`)
         ) {
             message.channel.send(translator.translateUppercase(`you don't have permission to add new teams`));
             return;

--- a/src/commands/utility/CleanChannel.ts
+++ b/src/commands/utility/CleanChannel.ts
@@ -18,7 +18,7 @@ export default class CleanChannel extends UtilityCommand {
 			undefined,
 			'[true/false]',
 			undefined,
-			["ADMINISTRATOR"],
+			[],
 			UserLevel.admin
 		)
 	}
@@ -26,7 +26,6 @@ export default class CleanChannel extends UtilityCommand {
 	async execute(message: Message, botSystem: BotSystem, args: any): Promise<void> {
 		if (
 			!message.member
-			|| !message.member.permissions.has("ADMINISTRATOR")
 		) {
 			message.channel.send("You need to be an administrator to do that.");
 			return


### PR DESCRIPTION
This is a small hotfix, that removes "ADMINISTRATOR" requirement, and uses the admin roles instead